### PR TITLE
Configure initial routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,4 @@
 Rails.application.routes.draw do
-  get 'pages/home'
   devise_for :users
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
-
-  # Defines the root path route ("/")
-  # root "posts#index"
+  root to: "pages#home"
 end


### PR DESCRIPTION
devise_for :users
Configures all the necessary routes for Devise to manage the User model (registration, login, logout, etc.).

root to: "pages#home"
Sets your application's home page to the PagesController's home action.