### PR TITLE
Log out link fixed

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -266,7 +266,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html, :turbo_stream]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :get
+  config.sign_out_via = :delete
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting


### PR DESCRIPTION
This way, the logout link will work correctly, as the HTTP method used by the link (DELETE) will be accepted by Devise.
